### PR TITLE
Corrected typos

### DIFF
--- a/CR.CyberRepublic/EBP.md
+++ b/CR.CyberRepublic/EBP.md
@@ -1,5 +1,5 @@
 # Gist
-Elastos is an open source project made for the community. We have reserved 16.5M ELA in order to reward the Elastos community members who contribute to the commmunity. EBP - Elastos Bounty Program is a web app platform for community members to take tasks, make contributions and get ELA as reward.
+Elastos is an open source project made for the community. We have reserved 16.5M ELA in order to reward the Elastos community members who contribute to the community. EBP - Elastos Bounty Program is a web app platform for community members to take tasks, make contributions and get ELA as reward.
 
 The whole EBP contains several subsidiary programs
 - Elastos Developer Bounty Program - EDBP. Developers contribute code to Elastos

--- a/CR.CyberRepublic/front-end/docs/constitution/conflict-of-interest.md
+++ b/CR.CyberRepublic/front-end/docs/constitution/conflict-of-interest.md
@@ -60,9 +60,9 @@ No Cyber Republic Council Member shall allow himself or herself to be influenced
 
 No Cyber Republic Council Member or member of their family shall accept any gift or other advantage, that might reasonably be seen to have been given to influence the Cyber Republic Council Member in the exercise of Cyber Republic Council power, duty or function.
 
-#### 11. Duty to Recuse
+#### 11. Duty to Recurse
 
-A Cyber Republic Council Member shall recuse himself or herself from any discussion, decision, debate or vote on any matter in respect of which he or she would be in a conflict of interest.
+A Cyber Republic Council Member shall recurse himself or herself from any discussion, decision, debate or vote on any matter in respect of which he or she would be in a conflict of interest.
 
 #### 12. Duty to Disclose
 

--- a/CR.CyberRepublic/front-end/docs/constitution/zh/conflict-of-interest.md
+++ b/CR.CyberRepublic/front-end/docs/constitution/zh/conflict-of-interest.md
@@ -60,7 +60,7 @@ No Cyber Republic Council Member shall allow himself or herself to be influenced
 
 No Cyber Republic Council Member or member of their family shall accept any gift or other advantage, that might reasonably be seen to have been given to influence the Cyber Republic Council Member in the exercise of Cyber Republic Council power, duty or function.
 
-#### 11. Duty to Recuse
+#### 11. Duty to Recurse
 
 A Cyber Republic Council Member shall recuse himself or herself from any discussion, decision, debate or vote on any matter in respect of which he or she would be in a conflict of interest.
 

--- a/CR.CyberRepublic/front-end/docs/guide/council.md
+++ b/CR.CyberRepublic/front-end/docs/guide/council.md
@@ -3,7 +3,7 @@
 
 The Council consists of **7** people elected by the community on an annual basis.
 
-**Their main responsibilties are:**
+**Their main responsibilities are:**
 
 1. Each safeguard a private key associated with 1 of the 12 Council non-rotating active DPoS nodes.
 

--- a/CR.CyberRepublic/front-end/experimental-docs/README.md
+++ b/CR.CyberRepublic/front-end/experimental-docs/README.md
@@ -2,7 +2,7 @@
 
 # Elastos Global - Documentation (Experimental)
 
-!> Note: These are not the official docs, while public these are our drafts and internal docs.<br/>Most of these are merged into the offcial documentation, however they may be of some use.
+!> Note: These are not the official docs, while public these are our drafts and internal docs.<br/>Most of these are merged into the official documentation, however they may be of some use.
 
 Use of these documents are at your own risk, we will not provide support for issues followed by this document.
 

--- a/CR.CyberRepublic/front-end/experimental-docs/core/arbiter/arbiter.md
+++ b/CR.CyberRepublic/front-end/experimental-docs/core/arbiter/arbiter.md
@@ -50,7 +50,7 @@ Do the same thing for the DID Sidechain keystore:
 
     - the `MainNode` is the connection to `Elastos.ELA`, so `SpvSeedList` should correspond to the IP and `NodeOpenPort`
     - You need a separate SideNode in `SideNodeList` for each side chain
-    - Each side chain's `GenesisBlock` needs to be retrived via something like `http://localhost:20604/api/v1/block/hash/0`, make sure you use the right port defined by `HttpRestPort`.
+    - Each side chain's `GenesisBlock` needs to be retrieved via something like `http://localhost:20604/api/v1/block/hash/0`, make sure you use the right port defined by `HttpRestPort`.
 
 4. Add the public keys from each of the Arbiter's primary keystore.dat to the `Arbiters` array in the `Elastos.ELA` mainchain `config.json`
 

--- a/CR.CyberRepublic/styleguide.md
+++ b/CR.CyberRepublic/styleguide.md
@@ -11,7 +11,7 @@ Everything is in eslint/tslint
 
 ##### CSS
 
-- `ord_` prefix for React class "overrideable" functions
+- `ord_` prefix for React class "overridable" functions
 - `c_` for component top level CSS class
 - `d_` for sub-components
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This is the repo that contains developer guides to get started. This is a work i
 Elastos SPV is a SDK of SPV (Simplified Payment Verification) implementation of the Elastos digital currency. The Elastos SPV SDK is a set of encryption algorithm, peer to peer network and SPV related implementation like bloom filter, merkleblock and util methods. As an example, this project includes an spv wallet implementation located in spvwallet folder. It will help you understand how to use this SDK and build your own apps. After installing, you can do some things locally like creating your own wallet, seeing account balance and a wide variety of other options.
 
 #### [Elastos.NET](https://github.com/elastos/Elastos.NET)
-Elasots.NET is a portal repository to introduce Elastos serivce infrastructures related with Network. As so far as writing this document, this repostiory includes the introductions of Elastos Carrier and Elastos Hive.
+Elasots.NET is a portal repository to introduce Elastos service infrastructures related with Network. As so far as writing this document, this repository includes the introductions of Elastos Carrier and Elastos Hive.
 
 #### [Elastos.ORG.Wallet.Service](https://github.com/elastos/Elastos.ORG.Wallet.Service)
 This repo provide simple HTTP Restful API for developers to interact with elastos blockchain. You may need to construct your own local node to use some of these API.


### PR DESCRIPTION
Changes made in:

- /README.md ("serivce" → "service")

- /README.md ("repostiory" → "repository")

- /CR.CyberRepublic/EBP.md ("commmunity" → "community")

- /CR.CyberRepublic/styleguide.md ("overrideable" → "overridable")

- /CR.CyberRepublic/front-end/docs/guide/council.md ("responsibilties" → "responsibilities")

- /CR.CyberRepublic/front-end/docs/constitution/conflict-of-interest.md ("Recuse" → "Recurse")

- /CR.CyberRepublic/front-end/docs/constitution/conflict-of-interest.md ("recuse" → "recurse")

- /CR.CyberRepublic/front-end/docs/constitution/zh/conflict-of-interest.md ("Recuse" → "Recurse")

- /CR.CyberRepublic/front-end/experimental-docs/README.md ("offcial" → "official")

- /CR.CyberRepublic/front-end/experimental-docs/core/arbiter/arbiter.md ("retrived" → "retrieved")
